### PR TITLE
Configure Kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath group: 'commons-io', name: 'commons-io', version: '2.5'
-        classpath group: 'org.zeroturnaround', name: 'zt-zip', version: '1.9'        
+        classpath group: 'org.zeroturnaround', name: 'zt-zip', version: '1.9'
     }
 }
 
@@ -32,6 +32,7 @@ allprojects {
     ext.slf4jVersion = '1.7.10'
     ext.gradlewVersion = '4.4.1'
     ext.toolsLibVersion = '26.0.0-dev'
+    ext.kotlinVersion = '1.2.71'
 
     Properties modeProperties = new Properties()
     modeProperties.load(project.rootProject.file("mode/mode.properties").newDataInputStream())
@@ -124,3 +125,4 @@ task dist {
                    file("dist/AndroidMode.txt").toPath(), REPLACE_EXISTING);
     }
 }
+

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 apply plugin: 'maven'
+apply plugin: 'kotlin'
 
 /**
  * Custom aar configuration needed to use aar files as dependencies in a pure java 
@@ -59,6 +60,7 @@ dependencies {
 
     aar "com.android.support:support-v4:${supportLibsVersion}"
     aar "com.google.android.support:wearable:${wearVersion}"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}"
 }
 
 /**
@@ -159,4 +161,25 @@ build.doLast {
                file("dist/processing-core-${modeVersion}-sources.jar").toPath(), REPLACE_EXISTING);
     Files.copy(file("$buildDir/libs/core.jar.MD5").toPath(),
                file("dist/processing-core-${modeVersion}.jar.md5").toPath(), REPLACE_EXISTING);
+}
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
+    }
+}
+repositories {
+    mavenCentral()
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/mode/build.gradle
+++ b/mode/build.gradle
@@ -2,6 +2,21 @@ import java.nio.file.Files
 import org.zeroturnaround.zip.ZipUtil
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
+apply plugin: 'kotlin'
+
+repositories {
+    mavenCentral()
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
 
 // Extend compile to copy the jars from gradle-tooling and slf4j:
 // https://stackoverflow.com/a/43602463
@@ -17,6 +32,7 @@ dependencies {
     compileAndCopy "org.gradle:gradle-tooling-api:${toolingVersion}"
     compileAndCopy "org.slf4j:slf4j-api:${slf4jVersion}"
     compileAndCopy "org.slf4j:slf4j-simple:${slf4jVersion}"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}"
 }
 
 // This task copies the gradle tooling jar into the mode folder
@@ -63,4 +79,12 @@ clean.doFirst {
 build.doLast {
     Files.copy(file("$buildDir/libs/mode.jar").toPath(),
                file("mode/AndroidMode.jar").toPath(), REPLACE_EXISTING);
+}
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
+    }
 }

--- a/mode/tools/SDKUpdater/build.gradle
+++ b/mode/tools/SDKUpdater/build.gradle
@@ -1,11 +1,37 @@
 import java.nio.file.Files
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
+apply plugin: 'kotlin'
+
+repositories {
+    mavenCentral()
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
+    }
+}
+
 dependencies {
     compile group: "org.processing", name: "pde", version: "${processingVersion}"
 
     compile name: "sdklib-${toolsLibVersion}"
     compile name: "repository-${toolsLibVersion}"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}"
 }
 
 sourceSets {


### PR DESCRIPTION
### What
This does the minimum work required to [configure Kotlin](https://kotlinlang.org/docs/reference/using-gradle.html) within `processing-android`'s `core` and `mode` libraries

### Why
We want to start to modernize the repository and given the recent [pushes Google has made](https://developer.android.com/kotlin/), it is clear that the Android community has adopted Kotlin as a first class language. Supporting Kotlin alongside Java will encourage more contributions as well as open up possibilities for [multiplatform](https://kotlinlang.org/docs/reference/multiplatform.html) support

### How
- Configures Kotlin version `1.2.71` for `core` and `mode` in the root `build.gradle`
- Applies the `kotlin` gradle plugin and adds a compile time dependency on `org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.71`

### Test
To test this, I made sure that the mode still compiled by running `./gradlew dist`