### PR TITLE
Migrate Interface to Kotlin

### DIFF
--- a/mode/src/processing/mode/android/DeviceListener.kt
+++ b/mode/src/processing/mode/android/DeviceListener.kt
@@ -19,12 +19,10 @@
  Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-package processing.mode.android;
+package processing.mode.android
 
-import java.util.List;
+interface DeviceListener {
+    fun stackTrace(trace: List<String>)
 
-public interface DeviceListener {
-  void stackTrace(final List<String> trace);
-
-  void sketchStopped();
+    fun sketchStopped()
 }


### PR DESCRIPTION
### What
Converts `DeviceListener.java` -> `DeviceListener.kt`

### Why
We are incrementally migrating the repository to Kotlin

### How
- Use Intellij's conversion tool:
<img width="1256" alt="1" src="https://user-images.githubusercontent.com/494323/58066532-bc1e8a00-7b57-11e9-8ed6-e2da5bfd4397.png">
- Verify that the `trace: List<String>` parameter should in fact be non-null (and other gotchas from converting don't exist)

### Test
To test this, I:
- Added logs to `AndroidRunner` (the class that implements this interface)
- Built the mode with`./gradlew dist`
- Unzipped the generated `AndroidMode.zip` into `Documents/Processing/modes/AndroidMode`
- Opened an example Sketch
- Ran it on my device
- Verified that my logs were present and the interface was working as before